### PR TITLE
Support embed in _search_direct_url

### DIFF
--- a/scihub/scihub.py
+++ b/scihub/scihub.py
@@ -197,9 +197,14 @@ class SciHub(object):
         res = self.sess.get(self.base_url + identifier, verify=False)
         s = self._get_soup(res.content)
         iframe = s.find('iframe')
+        embed = s.find('embed')
         if iframe:
             return iframe.get('src') if not iframe.get('src').startswith('//') \
                 else 'http:' + iframe.get('src')
+        elif embed:
+            r = embed.get('src') if not embed.get('src').startswith('//') \
+                else 'http:' + embed.get('src')
+            return r + '.pdf'
 
     def _classify(self, identifier):
         """


### PR DESCRIPTION
Found a problem with attempting to download some articles.
If an iframe is not used, but instead an embed tag, this would generate a  "(resolved url None) due to request exception." error, because no file would be found, since there is no iframe.